### PR TITLE
Add optional CAN FD support

### DIFF
--- a/damiao_motor/core/controller.py
+++ b/damiao_motor/core/controller.py
@@ -116,6 +116,7 @@ class DaMiaoController:
         self,
         channel: str = "can0",
         bustype: str = "socketcan",
+        fd: bool = False,
         bitrate: Optional[int] = None,
         **kwargs: Any,
     ) -> None:
@@ -149,6 +150,7 @@ class DaMiaoController:
         bus_kwargs: Dict[str, Any] = {
             "channel": channel,
             "interface": bustype,
+            "fd": fd,
             **kwargs,
         }
         if bitrate is not None:
@@ -162,6 +164,7 @@ class DaMiaoController:
         self._polling_thread: Optional[threading.Thread] = None
         self._polling_active = False
         self._polling_lock = threading.Lock()
+        self._fd = fd
 
     # -----------------------
     # Motor management
@@ -192,6 +195,7 @@ class DaMiaoController:
             feedback_id=feedback_id,
             bus=self.bus,
             motor_type=motor_type,
+            fd=self._fd,
             **kwargs,
         )
         self.motors[motor_id] = motor

--- a/damiao_motor/core/motor.py
+++ b/damiao_motor/core/motor.py
@@ -441,7 +441,10 @@ class DaMiaoMotor:
 
         try:
             msg = can.Message(
-                arbitration_id=arbitration_id, data=data, is_extended_id=False, is_fd=self._fd
+                arbitration_id=arbitration_id,
+                data=data,
+                is_extended_id=False,
+                is_fd=self._fd,
             )
             self.bus.send(msg)
         except OSError as e:
@@ -928,7 +931,7 @@ class DaMiaoMotor:
             raise ValueError(
                 f"Unknown data_type: {reg_info.data_type} for register {rid}"
             )
-        
+
         # Clear stale cache before sending write command.
         with self.registers_lock:
             self.registers.pop(rid, None)

--- a/damiao_motor/core/motor.py
+++ b/damiao_motor/core/motor.py
@@ -279,6 +279,7 @@ class DaMiaoMotor:
         motor_id: int,
         feedback_id: int,
         bus: can.Bus,
+        fd: bool,
         *,
         motor_type: str,
         p_min: Optional[float] = None,
@@ -323,6 +324,7 @@ class DaMiaoMotor:
         self.register_request_time_lock = threading.Lock()
         self.register_reply_time: Dict[int, float] = {}
         self.register_reply_time_lock = threading.Lock()
+        self._fd = fd
 
     def _resolve_limits(self, motor_type: str) -> Dict[str, float]:
         """Resolve limits from motor_type preset. Returns a dict of the 6 P/V/T limit values."""
@@ -439,7 +441,7 @@ class DaMiaoMotor:
 
         try:
             msg = can.Message(
-                arbitration_id=arbitration_id, data=data, is_extended_id=False
+                arbitration_id=arbitration_id, data=data, is_extended_id=False, is_fd=self._fd
             )
             self.bus.send(msg)
         except OSError as e:

--- a/damiao_motor/core/motor.py
+++ b/damiao_motor/core/motor.py
@@ -928,6 +928,10 @@ class DaMiaoMotor:
             raise ValueError(
                 f"Unknown data_type: {reg_info.data_type} for register {rid}"
             )
+        
+        # Clear stale cache before sending write command.
+        with self.registers_lock:
+            self.registers.pop(rid, None)
 
         # Send write command
         self._send_register_cmd(0x55, rid, data_bytes)


### PR DESCRIPTION
## Summary

Add an optional `fd` flag to enable CAN FD support for python-can / SocketCAN.

When `fd=True`, the controller initializes the CAN bus with FD support and sends messages with `is_fd=True`.

This PR also clears stale register cache entries before sending a `write_register()` command. This is related to #4, where control mode verification may fail after a power cycle because the motor firmware can take time to update and respond. Clearing the stale cache prevents a follow-up read from accidentally using an old cached value immediately after a write command.

## Notes

The default is `fd=False`, so existing classic CAN behavior remains unchanged.

The cache clearing only removes the entry for the register being written, and does not clear the entire register cache.