### PR TITLE
Add CAN FD high-speed baud rate support

### DIFF
--- a/damiao_motor/core/motor.py
+++ b/damiao_motor/core/motor.py
@@ -1170,6 +1170,7 @@ class DaMiaoMotor:
 
         Args:
             baud_rate_code: Baud rate code (0=125K, 1=200K, 2=250K, 3=500K, 4=1M, 5=2M, 6=2.5M, 7=3.2M, 8=4M, 9=5M)
+            persist: Store all current parameters to flash. The motor need to be in disabled Mode for this to work.
 
         Raises:
             ValueError: If baud_rate_code is not in valid range [0, 9]

--- a/damiao_motor/core/motor.py
+++ b/damiao_motor/core/motor.py
@@ -142,6 +142,14 @@ CAN_BAUD_RATE_CODES = {
     4: 1000000,  # 1M
 }
 
+# CAN_FD baud rate codes
+CAN_FD_BAUD_RATE_CODES = {
+    5: 2000000,  # 2M
+    6: 2500000,  # 2.5M
+    7: 3200000,  # 3.2M
+    8: 4000000,  # 4M
+    9: 5000000,  # 5M
+}
 
 # -----------------------
 # Helper functions

--- a/damiao_motor/core/motor.py
+++ b/damiao_motor/core/motor.py
@@ -1164,20 +1164,21 @@ class DaMiaoMotor:
         """Set speed loop enhancement coefficient (register 34)."""
         self.write_register(34, value)
 
-    def set_can_baud_rate(self, baud_rate_code: int) -> None:
+    def set_can_baud_rate(self, baud_rate_code: int, persist: bool = True) -> None:
         """
         Set CAN baud rate using register 35 (can_br).
 
         Args:
-            baud_rate_code: Baud rate code (0=125K, 1=200K, 2=250K, 3=500K, 4=1M)
+            baud_rate_code: Baud rate code (0=125K, 1=200K, 2=250K, 3=500K, 4=1M, 5=2M, 6=2.5M, 7=3.2M, 8=4M, 9=5M)
 
         Raises:
-            ValueError: If baud_rate_code is not in valid range [0, 4]
+            ValueError: If baud_rate_code is not in valid range [0, 9]
         """
-        if baud_rate_code not in CAN_BAUD_RATE_CODES:
+        if baud_rate_code not in CAN_BAUD_RATE_CODES and baud_rate_code not in CAN_FD_BAUD_RATE_CODES:
             raise ValueError(
-                f"Invalid baud rate code: {baud_rate_code}. Must be in {list(CAN_BAUD_RATE_CODES.keys())}"
+                f"Invalid baud rate code: {baud_rate_code}. Must be in {list(CAN_BAUD_RATE_CODES.keys())} or {list(CAN_FD_BAUD_RATE_CODES.keys())}"
             )
 
         self.write_register(35, baud_rate_code)  # Register 35 is can_br
-        self.store_parameters()  # Store to flash so it persists
+        if persist:
+            self.store_parameters()  # Store to flash so it persists


### PR DESCRIPTION
# Summary
Extends set_can_baud_rate to accept the new five CAN FD baud rate codes (5–9).

# Changes
- Adds CAN_FD_BAUD_RATE_CODES mapping codes 5–9 to their corresponding bit rates (2M–5M).
- Updates the validation in set_can_baud_rate to accept codes from either CAN_BAUD_RATE_CODES or CAN_FD_BAUD_RATE_CODES.
- persist flag for set_can_baud_rate since the motor has a limiting number of writes. Default is true so that existing implementations wont break.

# Notes
- Switching between can and can fd still requires multiple manual steps. The user needs to change the baudrate on the old bus but the parameter store needs to hapen on a new but with the respective change.